### PR TITLE
Remove `qs` from list

### DIFF
--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -27,7 +27,6 @@ last-index-of | `Array.prototype.lastIndexOf` |
 left-pad | `String.prototype.padStart` |
 pad-left | `String.prototype.padStart` |
 q | `Promise` | Use native promises
-qs | `URLSearchParams` | `URLSearchParams` is built in to the platform
 query-string | `URLSearchParams` | `URLSearchParams` is built in to the platform
 querystring | `URLSearchParams` | `URLSearchParams` is built in to the platform
 querystringify | `URLSearchParams` | `URLSearchParams` is built in to the platform


### PR DESCRIPTION
On the basic KV-pair structure of a query: `qs` is indeed made redundant by `URLSearchParams`. But, `qs` supports a superset of the URL Query Syntax that supports deeply nested data, and acts differently is certain conditions.

The reason a more complicated format become useful in situations where you need to transmit non-path data in HTTP methods like GET. For instance, applications like Strapi strictly adhere to the HTTP method definition but needs additional information for functions like nested data population.

In this changeset, I've removed the whole recommendation, but I accept that another change would be to recommend only using `qs` if you need the superset support.

## Examples

### Stringifying

```js
const data = {
  nested: {
    data: {
      is: ["supported", "and", "expressed"],
    },
  },
}

new URLSearchParams(data).toString()
// nested=[object+Object]
qs.stringify(data)
// nested[data][is][0]=supported&nested[data][is][1]=and&nested[data][is][2]=expressed
```

<small>\* I've URI decoded the strings for clarity</small>

### Parsing

```js
const q1 =
  "nested[data][is][0]=supported&nested[data][is][1]=and&nested[data][is][2]=expressed";

Object.fromEntries(new URLSearchParams(q1))
/* {
  'nested[data][is][0]': 'supported',
  'nested[data][is][1]': 'and',
  'nested[data][is][2]': 'expressed'
} */
qs.parse(q1)
// { nested: { data: { is: ['supported', 'and', 'expressed] } } }
```

```js
const q2 =
  "repeated=keys&repeated=are&repeated=supported&repeated=differently&repeated="

new URLSearchParams(q2)
/* URLSearchParams {
  'repeated' => 'keys',
  'repeated' => 'are',
  'repeated' => 'supported',
  'repeated' => 'differently',
  'repeated' => '' } */
qs.parse(q2)
// { repeated: [ 'keys', 'are', 'supported', 'differently', '' ] }
```

## Aside about `URL`

Tangential FYI: `URLSearchParams` is fine for most applications, but `URL` is finicky. Depending on environment (Node vs Browser), it may or may-not parse the string as a URL or URL-like. For instance:

-  `mongodb://...` URL will not be treated as a URL in the browser, but will in Node.
    A demonstraction is available [here](https://jsdom.github.io/whatwg-url/#url=bW9uZ29kYjovL3VzZXI6cGFzc3dvcmRAbW9uZ29zZXJ2ZXI6MjcwMTcvZGJuYW1lP2hlbGxvPXdvcmxk&base=YWJvdXQ6Ymxhbms=).
- `chrome:...` ends up getting special treatment and will get treated as if it is a URL, while being out of spec.

Most of the time people use HTTP(S) URLs and will never face this problem, but sometimes this can require avoiding the built-in.
